### PR TITLE
마민지 - 1주차 코드 제출

### DIFF
--- a/week1/마민지_15649.java
+++ b/week1/마민지_15649.java
@@ -1,0 +1,45 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static int N;
+    public static int M;
+    public static int[] rtnArr;
+    public static boolean[] checkArr;
+    public static StringBuilder sb = new StringBuilder();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+
+        rtnArr = new int[M];
+        checkArr = new boolean[N + 1];
+
+        recursive(0);
+        System.out.println(sb);
+    }
+
+    public static void recursive(int depth) {
+        if (depth == M) {
+            for (int num :
+                    rtnArr) {
+                sb.append(num).append(' ');
+            }
+            sb.append('\n');
+            return;
+        }
+        for (int i = 1; i <= N; i++) {
+            if (checkArr[i] == false) {
+                rtnArr[depth] = i;
+                checkArr[i] = true;
+                recursive(depth + 1);
+                checkArr[i] = false;
+            }
+        }
+    }
+}

--- a/week1/마민지_1931.java
+++ b/week1/마민지_1931.java
@@ -1,0 +1,48 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.StringTokenizer;
+
+public class Main {
+    public static int N;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int totalMeeting = 0;
+        int prevEndMeetingTime = 0;
+
+        N = Integer.parseInt(st.nextToken());
+
+        int[][] inputArr = new int[N][2];
+
+        for(int i = 0; i < N; i++) {
+            st = new StringTokenizer(br.readLine(), " ");
+            inputArr[i][0] = Integer.parseInt(st.nextToken());
+            inputArr[i][1] = Integer.parseInt(st.nextToken());
+        }
+
+        Arrays.sort(inputArr, new Comparator<int[]>() {
+            @Override
+            public int compare(int[] o1, int[] o2) {
+                if(o1[1]==o2[1]){
+                    return o1[0] - o2[0];
+                }else{
+                    return o1[1] - o2[1];
+                }
+            }
+        });
+
+        for(int i = 0; i < N; i++) {
+            if(prevEndMeetingTime <= inputArr[i][0]) {
+                prevEndMeetingTime = inputArr[i][1];
+                totalMeeting++;
+            }
+        }
+
+        System.out.println(totalMeeting);
+    }
+
+}


### PR DESCRIPTION
 1주차 스터디 코드 설명
해당 이슈 : #1 

## 백준 15649번 N과 M(1)
<img width="1165" alt="스크린샷 2022-11-16 오후 1 18 56" src="https://user-images.githubusercontent.com/112615871/202082550-59817ac3-a515-4631-b0ac-afc5e39fd936.png">

- StringBuilder를 사용하여, 출력을 매번 해줄 필요 없이 하나의 문자열로 묶어서 출력해 효율성을 높였다.
- BufferedReader를 사용하여, 사용자가 요청할 때마다 데이터를 읽어 오는 것이 아닌 일정한 크기의 데이터를 한번에 읽어와 버퍼에 보관 한 후, 사용자의 요청이 있을 때 버퍼에서 데이터를 읽어오는 방식으로 동작하므로 속도가 향상되고 시간부하가 적도록 하였다.
- 일정 depth M값에 도달할 떄까지, 재귀를 통해, 1~N까지의 경우를 살폈다.

### 예제
-> N : 4, M : 2
1. (depth : 0) 첫번째 자리 수에 대해 찾기위해 depth 0으로 재귀함수 recursive 실행
2. (depth : 0) recursive는 먼저 1에 대해 수행하는데, 이미 수행한적있는지 확인 한뒤
3. (depth : 0) 수행한적이 없으므로, 확인했음을 저장하고, 1을 '출력할 수 배열'에 저장한 뒤, 그다음 depth 값으로 재귀를 수행한다
4. (depth : 1) depth 1로 실행된 재귀함수 recursive는, 먼저 1에 대해 수행하는데, 이미 수행한적이 있으므로 그다음 수로 넘어간다.
5. (depth : 1) 그다음 수는 2로, 이미 수행한 적 있는지 확인해보니 수행하지 않았으므로, 확인했음을 저장하고, 2를 '출력할 수 배열'에 저장한다. 그리고 그 다음 depth 값 2로 재귀를 수행한다.
6. (depth : 2) depth 2로 실행된 재귀함수 recursive는, 현재 depth가 M과 일치하므로 지금까지 저장한 수를 출력한다. ( => 1 2 )
7. (depth : 1) depth는 1이고, 수행중인 수는 2인 상태인데, 이미 현재 수에 대해서는 작업을 마쳤으나, 다음에 올 수의 depth들에 이 수가 사용될 수 있어야하므로, 확인했음을 해제하도록 저장한다. 
8. (depth : 1) 2에 대한 수행을 마쳤으므로 3에 대해 수행한다. 위의 과정을 반복한다. 

7번의 경우는, M>=3인 경우에 더 이해가 쉽다. depth = 2이고, 현재 수행중인 수가 3일때, 재귀를 통해 '1 2 3'을 출력했다면, 3을 확인한 배열에서 해제 시켜주어야한다. 확인한 배열에서 해제 시켜주지 않으면 '1 3 2', '1 4 3' 등 3이 필요한 배열을 출력할 수 없다. 


## 백준 1931번 회의실 배정
<img width="1162" alt="스크린샷 2022-11-16 오후 1 35 42" src="https://user-images.githubusercontent.com/112615871/202084671-babdf99c-d29d-4844-b6a9-136f37170397.png">

- BufferedReader를 사용하여, 사용자가 요청할 때마다 데이터를 읽어 오는 것이 아닌 일정한 크기의 데이터를 한번에 읽어와 버퍼에 보관 한 후, 사용자의 요청이 있을 때 버퍼에서 데이터를 읽어오는 방식으로 동작하므로 속도가 향상되고 시간부하가 적도록 하였다.
- '**서로 겹치지 않는 활동에 대해 종료시간이 빠르면 더 많은 활동을 선택할 수 있는 시간이 많아진다**'는 점을 가지고 이 문제를 풀 수 있다. 따라서, 입력받은 배열은 '종료 시간이 빠른 순서대로' 정렬한다. 
- 이후, 각 회의에 대해, 현재 확인하고 있는 회의 시작 시간이 이전에 유효한 회의 종료 시간과 겹치지 않는다면, 유효한 회의에 포함시킨다.
