### PR TITLE
이하늘 - 5주차 코드 제출

### DIFF
--- a/week5/이하늘_1406시간초과.java
+++ b/week5/이하늘_1406시간초과.java
@@ -1,0 +1,73 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.List;
+
+public class Main {
+
+    private static final LinkedList<String> linkedList = new LinkedList<>();
+    private static int m;
+    private static int nowCursor;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(System.in));
+        setValues(bufferedReader);
+
+        for (int i = 0; i < m; i++) {
+            String[] commands = bufferedReader.readLine().split(" ");
+            processCommand(commands);
+        }
+
+        System.out.println(result());
+    }
+
+    private static void setValues(BufferedReader bufferedReader) throws IOException {
+        linkedList.addAll(List.of(bufferedReader.readLine().split("")));
+        m = Integer.parseInt(bufferedReader.readLine());
+        nowCursor = linkedList.size();
+    }
+
+    private static void processCommand(String[] commands) {
+        String command = commands[0];
+        switch (command) {
+            case "L":
+                moveLeft();
+                break;
+            case "D":
+                moveRight();
+                break;
+            case "B":
+                deleteLeft();
+                break;
+            case "P":
+                insertLeft(commands[1]);
+                break;
+        }
+    }
+
+    private static void insertLeft(String param) {
+        linkedList.add(nowCursor, param);
+        moveRight();
+    }
+
+    private static void deleteLeft() {
+        if (nowCursor == 0) return;
+        moveLeft();
+        linkedList.remove(nowCursor);
+    }
+
+    private static void moveRight() {
+        nowCursor = Math.min(nowCursor + 1, linkedList.size());
+    }
+
+    private static void moveLeft() {
+        nowCursor = Math.max(nowCursor - 1, 0);
+    }
+
+    private static String result() {
+        return String.join("", linkedList);
+    }
+}
+
+

--- a/week5/이하늘_21201.java
+++ b/week5/이하늘_21201.java
@@ -1,0 +1,168 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class Main {
+    private static int minute = 0;
+
+    public static void main(String[] args) throws IOException {
+        StringBuilder stringBuilder = new StringBuilder();
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(System.in));
+        DoublyLinkedList doublyLinkedList = new DoublyLinkedList();
+        int n = Integer.parseInt(bufferedReader.readLine());
+        StringTokenizer stringTokenizer = new StringTokenizer(bufferedReader.readLine());
+
+        for (int i = 0; i < n; i++)
+            doublyLinkedList.append(Integer.parseInt(stringTokenizer.nextToken()));
+
+        while (true) {
+            String deleteNode = doublyLinkedList.findDeleteNode();
+            if (deleteNode.equals(""))
+                break;
+
+            stringBuilder.append(deleteNode).append("\n");
+            minute++;
+        }
+
+        System.out.println(minute);
+        if (stringBuilder.length() != 0)
+            System.out.println(stringBuilder.toString().strip());
+
+        doublyLinkedList.display();
+    }
+
+    static class Node {
+
+        public int value;
+        public Node next;
+        public Node prev;
+
+        public Node(int value) {
+            this.value = value;
+            this.next = null;
+            this.prev = null;
+        }
+
+        public boolean toBeDeleted() {
+            int prevValue = (prev != null) ? prev.value : 0;
+            int nextValue = (next != null) ? next.value : 0;
+            return this.value < prevValue || this.value < nextValue;
+        }
+
+        @Override
+        public String toString() {
+            return Integer.toString(value);
+        }
+    }
+
+    static class DoublyLinkedList {
+
+        public Node head;
+        public Node tail;
+
+        //다음 라운드에 판단할 노드들
+        private Set<Node> nextNodes;
+
+        public DoublyLinkedList() {
+            this.head = null;
+            this.tail = null;
+            this.nextNodes = new LinkedHashSet<>();
+        }
+
+        public void append(int value) {
+            Node node = new Node(value);
+            if (this.head == null) {
+                this.head = node;
+            } else {
+                this.tail.next = node;
+                node.prev = this.tail;
+            }
+            this.tail = node;
+        }
+
+        public void remove(Node node) {
+            Node prev = node.prev;
+
+            //if target is first node
+            if (prev == null) {
+                if (node.next != null) {
+                    this.head = node.next;
+                    node.next.prev = null;
+                } else {
+                    this.head = null;
+                    this.tail = null;
+                }
+
+                return;
+            }
+
+            //npe safe
+            if (node.next == null) {
+                prev.next = null;
+                this.tail = prev;
+            } else {
+                prev.next = node.next;
+                node.next.prev = prev;
+            }
+        }
+
+        public String findDeleteNode() {
+            StringBuilder stringBuilder = new StringBuilder();
+            List<Node> deleted = new ArrayList<>();
+            if (nextNodes.isEmpty()) {
+                Node current = this.head;
+                while (current != null) {
+                    if (current.toBeDeleted()) {
+                        stringBuilder.append(current).append(" ");
+                        deleted.add(current);
+
+                        //다음 실행 노드 캐싱
+                        nextNodes.add(current.prev);
+                        nextNodes.add(current.next);
+                    }
+                    current = current.next;
+                }
+            } else {
+                Set<Node> temp = new LinkedHashSet<>();
+                for (Node current : nextNodes) {
+                    if (current == null)
+                        continue;
+
+                    if (!current.toBeDeleted())
+                        continue;
+
+                    stringBuilder.append(current).append(" ");
+                    deleted.add(current);
+
+                    //다음 실행 노드 캐싱
+                    temp.add(current.prev);
+                    temp.add(current.next);
+                }
+                nextNodes = temp;
+            }
+
+            // 다음 실행 노드 중 삭제 예정인 노드 제외
+            nextNodes = this.nextNodes.stream()
+                    .filter(node -> !deleted.contains(node))
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+
+
+            deleted.forEach(this::remove);
+            return stringBuilder.toString().trim();
+        }
+
+        public void display() {
+            StringBuilder stringBuilder = new StringBuilder();
+            Node current = this.head;
+
+            while (current != null) {
+                stringBuilder.append(current).append(" ");
+                current = current.next;
+            }
+
+            System.out.println(stringBuilder.toString().trim());
+        }
+    }
+}

--- a/week5/이하늘_22645.java
+++ b/week5/이하늘_22645.java
@@ -1,0 +1,44 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class Main {
+
+    // number of accessed Ids
+    private static int n;
+    // size of the cache
+    private static int m;
+    private static final Stack<Integer> ids = new Stack<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(System.in));
+        String[] s = bufferedReader.readLine().split(" ");
+
+        n = Integer.parseInt(s[0]);
+        m = Integer.parseInt(s[1]);
+        for (int i = 0; i < n; i++)
+            ids.add(Integer.parseInt(bufferedReader.readLine()));
+
+        System.out.println(solution());
+    }
+
+    private static String solution() {
+        List<Integer> cache = new ArrayList<>();
+        for (int i = 0; i < m; i++) {
+            if(ids.empty())
+                break;
+            Integer pop = ids.pop();
+            if (!cache.contains(pop))
+                cache.add(pop);
+        }
+
+        StringBuilder stringBuilder = new StringBuilder();
+        for (Integer integer : cache) {
+            stringBuilder.append(integer).append("\n");
+        }
+
+        return stringBuilder.toString();
+    }
+}
+

--- a/week5/이하늘_2983시간초과.java
+++ b/week5/이하늘_2983시간초과.java
@@ -1,0 +1,105 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class Main {
+
+    // 식물의 갯수
+    private static int n;
+    // 점프
+    private static int k;
+    private static Queue<String> commands;
+    private static List<PlantPosition> plants = new LinkedList<>();
+    private static HashMap<String, Predicate<PlantPosition>> directions = new HashMap<>();
+
+    //현재 개구리
+    private static PlantPosition now = null;
+
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(System.in));
+        String[] s = bufferedReader.readLine().split(" ");
+        commands = new LinkedList<>();
+        commands.addAll(List.of(bufferedReader.readLine().split("")));
+        n = Integer.parseInt(s[0]);
+        k = Integer.parseInt(s[1]);
+
+        for (int i = 0; i < n; i++) {
+            List<Integer> position = Arrays.stream(bufferedReader.readLine().split(" "))
+                    .mapToInt(Integer::parseInt)
+                    .boxed()
+                    .collect(Collectors.toList());
+
+            PlantPosition pos = new PlantPosition(position.get(0), position.get(1));
+            if (now != null)
+                plants.add(pos);
+            else
+                now = pos;
+        }
+        setDirections();
+        solution();
+        System.out.println(now.toString());
+    }
+
+    // P는 양의 정수인데, 0은 양의 정수가 아니므로 대각으로만 갈 수 있음
+    private static void setDirections() {
+        directions.put("A", (plantPosition -> now.getX() < plantPosition.getX() && now.getY() < plantPosition.getY()));
+        directions.put("B", (plantPosition -> now.getX() < plantPosition.getX() && now.getY() > plantPosition.getY()));
+        directions.put("C", (plantPosition -> now.getX() > plantPosition.getX() && now.getY() < plantPosition.getY()));
+        directions.put("D", (plantPosition -> now.getX() > plantPosition.getX() && now.getY() > plantPosition.getY()));
+    }
+
+    private static void solution() {
+        while (k != 0 && !commands.isEmpty()) {
+            String command = commands.poll();
+            Predicate<PlantPosition> plantPositionPredicate = directions.get(command);
+            List<PlantPosition> finds = plants.stream()
+                    .filter(plantPositionPredicate)
+                    .collect(Collectors.toList());
+
+
+
+            if (finds.size() > 1)
+                finds.sort((o1, o2) -> (int) (o1.hypotenuse() - o2.hypotenuse()));
+
+            if (finds.size() > 0) {
+                now = finds.get(0);
+                plants.remove(now);
+                k--;
+            }
+        }
+    }
+
+    static class PlantPosition {
+
+        private final int x;
+        private final int y;
+
+        public PlantPosition(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        public double hypotenuse() {
+            int xLength = now.getX() - x;
+            int yLength = now.getY() - y;
+            return Math.sqrt(Math.pow(xLength, 2) + Math.pow(yLength, 2));
+        }
+
+        public int getX() {
+            return x;
+        }
+
+        public int getY() {
+            return y;
+        }
+
+        @Override
+        public String toString() {
+            return x + " " + y;
+        }
+    }
+}


### PR DESCRIPTION
## 5주차 스터디 코드 설명
해당 이슈 : #18 

## 백준 22645번 cache control

![image](https://user-images.githubusercontent.com/39932141/208896709-4b440828-5ab7-4ac1-ac55-5f58ffe120cf.png)

- [바로가기](https://www.acmicpc.net/problem/22645)

> 지문이 영어라서 당황했는데, LRU라고 써있는 거 보고 반가웠습니다.

-  id들을 stack에 적재
-  캐시 사이즈 만큼 stack에서 pop해서 중복 없이 캐시에 적재

## 백준 21201 interview queue

![image](https://user-images.githubusercontent.com/39932141/209041733-3194b59a-1c04-4a18-99f0-ccfd97e2f33c.png)


- [바로가기](https://www.acmicpc.net/problem/21201)

- 문제 설명
```
면접자들이 한줄로 서있고 매 분마다 동시에 좌우에 있는 지원자의 가치를 판단해서 자신보다 높다면
줄에서 이탈하는 로직을 구현해야하는 문제입니다. 더이상 면접자들이 대기열을 떠나지 않을때까지 이탈하는
로직을 반복한 이후에, 걸린 시간, 매 라운드 이탈자, 최종 대기열을 출력하는 문제입니다.
```
- 처음 접근
    -  직접 이중 연결 리스트 구현
    -  매 라운드 마다, 모든 노드의 prev와 next를 비교한다음에, 삭제할 노드를 판단 후 삭제
    -  최악의 경우 총 라운드 * N의 시간 복잡도를 가지기 때문에 시간초과가 발생

- 개선
    - 다음 라운드에서는 이전에 삭제한 노드의 prev와 next 노드만 판단해도 된다는 점을 이용해서 개선
    - 좌우의 중복을 제거하고, 순서를 보장하기 위해서 LinkedHashSet 사용
    - 매 라운드마다 nextNode(LinkedHashSet)에 삭제할 노드의 prev와,  next를 삽입
    - 매 라운드마다 생성하는 삭제 노드 목록에 있는 노드는 nextNode에서 삭제
    - 다음 라운드에서는 nextNode에서 하나씩 꺼내서 삭제 여부 판단


## 백준 2983번, 1406번 시간초과

2983 개구리 공주 문제랑 1406 에디터 문제 연결 리스트로 풀고 있었는데, 시간초과로 혼나고 있다가 카페 마감 시간이라서 부랴부랴 제출해봅니다.. 

아마도 개구리 공주 문제는 처음부터 연결리스트를  정렬 해야할 것 같다고 느꼈어요

에디터 문제는.. 연결리스트 요소 삭제나 추가할 때  index의 node를 찾을때까지 탐색하는 시간 + 처음에 데이터를 연결리스트에 적재하는 시간때문인 것 같아요.

위 이유 말고 다른 이유가 있다면 피드백 부탁드립니다.🙇‍♂️🙇‍♂️


