### PR TITLE
이하늘 - 6주차 코드 제출

### DIFF
--- a/week6/이하늘_1662.java
+++ b/week6/이하늘_1662.java
@@ -1,0 +1,42 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Stack;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String compressed = br.readLine();
+
+        // 열리는 괄호가 나오기 전의 숫자를 제외하고 계산된 길이
+        Stack<Integer> lengthStack = new Stack<>();
+
+        // 열리는 괄호 직전에 나온 숫자를 저장 (k)
+        Stack<Integer> multiStack = new Stack<>();
+
+        int count = 0;
+
+        for (int i = 0; i < compressed.length(); i++) {
+            char targetChar = compressed.charAt(i);
+
+            if (targetChar == '(') {
+                int multiNumber = compressed.charAt(i - 1) - '0';
+                count -= 1;
+                lengthStack.add(count);
+                multiStack.add(multiNumber);
+                count = 0;
+            } else if (targetChar == ')') {
+                int val = multiStack.peek();
+                multiStack.pop();
+                val *= count;
+
+                int plus = lengthStack.peek();
+                lengthStack.pop();
+                count = plus + val;
+            } else count++;
+        }
+
+        System.out.print(count);
+    }
+}
+

--- a/week6/이하늘_6198.java
+++ b/week6/이하늘_6198.java
@@ -1,0 +1,41 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+    private static int n;
+    private static int[] buildings;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(bufferedReader.readLine());
+        buildings = new int[n];
+
+        for (int i = 0; i < n; i++) {
+            buildings[i] = Integer.parseInt(bufferedReader.readLine());
+        }
+
+        System.out.println(solution());
+    }
+
+    private static long solution() {
+        long result = 0;
+
+        for (int i = 0; i < buildings.length; i++) {
+            int building = buildings[i];
+            int stack = 0;
+
+            for (int j = i + 1; j < buildings.length; j++) {
+                int targetBuilding = buildings[j];
+                if (targetBuilding < building)
+                    stack++;
+                else
+                    break;
+            }
+
+            result += stack;
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## 6주차 스터디 코드 설명
해당 이슈 : #21 

## 백준 6198번 [옥상 정원 꾸미기](https://www.acmicpc.net/problem/6198)

![image](https://user-images.githubusercontent.com/39932141/209826543-afb11dee-aaf0-4103-871d-c0b72bc061a5.png)

- for..i 를 빌딩의 길이 만큼 하면서 building[i]를 선택합니다.
- 스택을 int 타입으로 표현하고, i + 1 부터 나머지 빌딩을 탐색
- 볼 수 있는 정원이라면 stack++ (스택에 푸시)하고, 자신 보다 큰 빌딩이 있다면 탐색을 종료합니다.
- stack의 길이를 result에 더합니다.

직접 Stack을 선언해서 사용 한다면, 메모리 초과가 나기 때문에 다른 방법으로 스택을 표현해야하는 문제였습니다.

## 백준 1662번 [압축](https://www.acmicpc.net/problem/1662)
![image](https://user-images.githubusercontent.com/39932141/209827289-1d2277a6-cfcf-4f3c-a700-c291a668d5a6.png)

처음 풀었을 때는 스택에 직접 스트링 넣어주는 식으로 풀었더니 메모리 초과한테 혼났어요, 두 번째 풀었을 때는 대부분의 테스트 케이스는 통과하는데 `3(1(1)3(2)` 처럼 내부에  multi * ((multi *string length) + (multi *string length)) 같은 케이스를 못 풀어서 결국에는 다른 분의 코드를 참고했습니다.

- length 스택은 '(' 가 나오기 직전의 숫자(k)를 제외하고 계산된 길이를 넣습니다.
- multi 스택은 '(' 가 나오기 직전의 숫자(k)를 저장합니다.

- 카운트를 0으로 초기화해서, 문자열을 좌에서 우로 검사합니다.
- 숫자가 나오면 카운트를 증가하고, `(`가 나오면 카운트를 계산해서 length 스택이랑 multi스택에 값을 추가합니다.
- 만약, ')'이 나오면 length 스택이랑 multi 스택에서 값을 뽑아서 계산하고, 카운트에 대입합니다.